### PR TITLE
Do not use wxGCDC on Linux/GTK. The problem with this is:

### DIFF
--- a/src/avg_wind.cpp
+++ b/src/avg_wind.cpp
@@ -183,7 +183,7 @@ void TacticsInstrument_AvgWindDir::CalcAvgWindDir(double CurWindDir)
  }
 }
 
-void TacticsInstrument_AvgWindDir::Draw(wxGCDC* dc)
+void TacticsInstrument_AvgWindDir::Draw(myDC* dc)
 {
   wxColour c1;
   GetGlobalColor(_T("DASHB"), &c1);
@@ -213,7 +213,7 @@ void TacticsInstrument_AvgWindDir::Draw(wxGCDC* dc)
 // *********************************************************************************
 //draw background
 // *********************************************************************************
-void TacticsInstrument_AvgWindDir::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_AvgWindDir::DrawBackground(myDC* dc)
 {
   wxString label;
   wxColour cl;
@@ -268,7 +268,7 @@ void TacticsInstrument_AvgWindDir::DrawBackground(wxGCDC* dc)
 //*********************************************************************************
 //draw foreground
 //*********************************************************************************
-void TacticsInstrument_AvgWindDir::DrawForeground(wxGCDC* dc)
+void TacticsInstrument_AvgWindDir::DrawForeground(myDC* dc)
 {
   wxColour col;
   int degw, degh;

--- a/src/avg_wind.h
+++ b/src/avg_wind.h
@@ -82,14 +82,14 @@ protected:
   int m_width, m_height, m_cx;
   wxSize size;
   int m_Legend;
-  void Draw(wxGCDC* dc);
-  void DrawBackground(wxGCDC* dc);
-  void DrawForeground(wxGCDC* dc);
+  void Draw(myDC* dc);
+  void DrawBackground(myDC* dc);
+  void DrawForeground(myDC* dc);
   double GetAvgWindDir();
   void OnAvgTimeSliderUpdated(wxCommandEvent& event);
   void CalcAvgWindDir(double CurWindDir);
   void OnAvgWindUpdTimer(wxTimerEvent & event);
-  //void DrawWindSpeedScale(wxGCDC* dc);
+  //void DrawWindSpeedScale(myDC* dc);
 };
 
 

--- a/src/baro_history.cpp
+++ b/src/baro_history.cpp
@@ -133,7 +133,7 @@ void TacticsInstrument_BaroHistory::SetData(int st, double data, wxString unit)
   }
 
 
-void TacticsInstrument_BaroHistory::Draw(wxGCDC* dc)
+void TacticsInstrument_BaroHistory::Draw(myDC* dc)
 {
    m_WindowRect = GetClientRect();
    m_DrawAreaRect=GetClientRect();
@@ -148,7 +148,7 @@ void TacticsInstrument_BaroHistory::Draw(wxGCDC* dc)
 //*********************************************************************************
 // draw pressure scale
 //*********************************************************************************
-void  TacticsInstrument_BaroHistory::DrawWindSpeedScale(wxGCDC* dc)
+void  TacticsInstrument_BaroHistory::DrawWindSpeedScale(myDC* dc)
 {
   wxString label1,label2,label3,label4,label5;
   wxColour cl;
@@ -215,7 +215,7 @@ void  TacticsInstrument_BaroHistory::DrawWindSpeedScale(wxGCDC* dc)
 //*********************************************************************************
 //draw background
 //*********************************************************************************
-void TacticsInstrument_BaroHistory::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_BaroHistory::DrawBackground(myDC* dc)
 {
   wxString label,label1,label2,label3,label4,label5;
   wxColour cl;
@@ -249,7 +249,7 @@ void TacticsInstrument_BaroHistory::DrawBackground(wxGCDC* dc)
 //*********************************************************************************
 //draw foreground
 //*********************************************************************************
-void TacticsInstrument_BaroHistory::DrawForeground(wxGCDC* dc)
+void TacticsInstrument_BaroHistory::DrawForeground(myDC* dc)
 {
   wxColour col;
   double ratioH;

--- a/src/baro_history.h
+++ b/src/baro_history.h
@@ -95,12 +95,12 @@ class TacticsInstrument_BaroHistory: public TacticsInstrument
             int m_currSec,m_lastSec,m_SpdCntperSec;
             double m_cntSpd,m_cntDir,m_avgSpd,m_avgDir;
 
-            void Draw(wxGCDC* dc);
-            void DrawBackground(wxGCDC* dc);
-            void DrawForeground(wxGCDC* dc);
+            void Draw(myDC* dc);
+            void DrawBackground(myDC* dc);
+            void DrawForeground(myDC* dc);
             void SetMinMaxWindScale();
 
-   void DrawWindSpeedScale(wxGCDC* dc);
+   void DrawWindSpeedScale(myDC* dc);
    //wxString GetWindDirStr(wxString WindDir);
 };
 

--- a/src/bearingcompass.cpp
+++ b/src/bearingcompass.cpp
@@ -184,7 +184,7 @@ void TacticsInstrument_BearingCompass::SetData(int st, double data, wxString uni
 }
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_BearingCompass::Draw(wxGCDC* bdc)
+void TacticsInstrument_BearingCompass::Draw(myDC* bdc)
 {
 	wxColour c1;
 	GetGlobalColor(_T("DASHB"), &c1);
@@ -225,14 +225,14 @@ void TacticsInstrument_BearingCompass::Draw(wxGCDC* bdc)
 }
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_BearingCompass::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_BearingCompass::DrawBackground(myDC* dc)
 {
     DrawCompassRose( dc, m_cx, m_cy, 0.7 * m_radius, m_AngleStart, true );
 	DrawBoat(dc, m_cx, m_cy, m_radius);
 }
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_BearingCompass::DrawWindAngles(wxGCDC* dc)
+void TacticsInstrument_BearingCompass::DrawWindAngles(myDC* dc)
 {
 	// draw the wind needles for AWA and TWA. We don't use the standard ones, as they are to big.
 	// 
@@ -400,7 +400,7 @@ void TacticsInstrument_BearingCompass::DrawWindAngles(wxGCDC* dc)
 /***************************************************************************************
 Draw pointers for the optimum target VMG- and CMG Angle (if bearing is available)
 ****************************************************************************************/
-void TacticsInstrument_BearingCompass::DrawTargetxMGAngle(wxGCDC* dc){
+void TacticsInstrument_BearingCompass::DrawTargetxMGAngle(myDC* dc){
   if (!wxIsNaN(m_TWS)) {
     // get Target VMG Angle from Polar
     TargetxMG tvmg_up = BoatPolar->GetTargetVMGUpwind(m_TWS);
@@ -427,7 +427,7 @@ void TacticsInstrument_BearingCompass::DrawTargetxMGAngle(wxGCDC* dc){
 /***************************************************************************************
 Draw pointers for the optimum target VMG- and CMG Angle (if bearing is available)
 ****************************************************************************************/
-void TacticsInstrument_BearingCompass::DrawTargetAngle(wxGCDC* dc, double TargetAngle, wxString color, int size){
+void TacticsInstrument_BearingCompass::DrawTargetAngle(myDC* dc, double TargetAngle, wxString color, int size){
     if (TargetAngle > 0){
       wxColour cl;
       dc->SetPen(*wxTRANSPARENT_PEN);
@@ -495,7 +495,7 @@ void TacticsInstrument_BearingCompass::DrawTargetAngle(wxGCDC* dc, double Target
 }
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_BearingCompass::DrawForeground(wxGCDC* dc)
+void TacticsInstrument_BearingCompass::DrawForeground(myDC* dc)
 {
 	if (!wxIsNaN(m_Bearing))  
 		DrawBearing(dc);
@@ -507,7 +507,7 @@ void TacticsInstrument_BearingCompass::DrawForeground(wxGCDC* dc)
 }
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_BearingCompass::DrawBearing(wxGCDC* dc)
+void TacticsInstrument_BearingCompass::DrawBearing(myDC* dc)
 {
 	wxColour cl;
 	// no border for the circle 
@@ -540,7 +540,7 @@ void TacticsInstrument_BearingCompass::DrawBearing(wxGCDC* dc)
 }
 /***************************************************************************************
 ****************************************************************************************/
-/*void TacticsInstrument_BearingCompass::DrawPolar(wxGCDC*dc)
+/*void TacticsInstrument_BearingCompass::DrawPolar(myDC*dc)
 {
   if (!wxIsNaN(m_TWS)) {
     wxColour cl;
@@ -579,7 +579,7 @@ void TacticsInstrument_BearingCompass::DrawBearing(wxGCDC* dc)
 }*/
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_BearingCompass::DrawCurrent(wxGCDC* dc)
+void TacticsInstrument_BearingCompass::DrawCurrent(myDC* dc)
 {
 	wxColour cl;
 
@@ -628,7 +628,7 @@ void TacticsInstrument_BearingCompass::DrawCurrent(wxGCDC* dc)
 
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_BearingCompass::DrawData(wxGCDC* dc, double value,
+void TacticsInstrument_BearingCompass::DrawData(myDC* dc, double value,
 	wxString unit, wxString format, DialPositionOption position)
 {
 	if (position == DIAL_POSITION_NONE)
@@ -768,7 +768,7 @@ void TacticsInstrument_BearingCompass::DrawData(wxGCDC* dc, double value,
 /***************************************************************************************
   Calculate & Draw the laylines for the bearing compass 
 ****************************************************************************************/
-void TacticsInstrument_BearingCompass::DrawLaylines(wxGCDC* dc)
+void TacticsInstrument_BearingCompass::DrawLaylines(myDC* dc)
 {
   if (!wxIsNaN(m_Cog) && !wxIsNaN(m_Hdt) && !wxIsNaN(m_lat) && !wxIsNaN(m_lon) && !wxIsNaN(m_TWA) && !wxIsNaN(m_CurrDir) && !wxIsNaN(m_CurrSpeed)){
 

--- a/src/bearingcompass.h
+++ b/src/bearingcompass.h
@@ -85,17 +85,17 @@ class TacticsInstrument_BearingCompass : public TacticsInstrument_Dial
 		  wxFileConfig     *m_pconfig;
 
       protected:
-            void DrawBackground(wxGCDC* dc);
-			void DrawForeground(wxGCDC* dc);
-			void DrawBearing(wxGCDC* dc);
-			void DrawWindAngles(wxGCDC* dc);
-            //void DrawPolar(wxGCDC* dc);
-            void DrawTargetxMGAngle(wxGCDC* dc);
-            void DrawTargetAngle(wxGCDC* dc, double TargetAngle, wxString color1, int size);
-            void DrawCurrent(wxGCDC* dc);
-			void DrawLaylines(wxGCDC* dc);
-			virtual void DrawData(wxGCDC* dc, double value, wxString unit, wxString format, DialPositionOption position);
-			virtual void Draw(wxGCDC* dc);
+            void DrawBackground(myDC* dc);
+			void DrawForeground(myDC* dc);
+			void DrawBearing(myDC* dc);
+			void DrawWindAngles(myDC* dc);
+            //void DrawPolar(myDC* dc);
+            void DrawTargetxMGAngle(myDC* dc);
+            void DrawTargetAngle(myDC* dc, double TargetAngle, wxString color1, int size);
+            void DrawCurrent(myDC* dc);
+			void DrawLaylines(myDC* dc);
+			virtual void DrawData(myDC* dc, double value, wxString unit, wxString format, DialPositionOption position);
+			virtual void Draw(myDC* dc);
 			void CalculateLaylineDegreeRange(void);
 };
 

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -100,7 +100,7 @@ void TacticsInstrument_Moon::SetData( int st, double value, wxString format )
     }
 }
 
-void TacticsInstrument_Moon::Draw(wxGCDC* dc)
+void TacticsInstrument_Moon::Draw(myDC* dc)
 {
     if ( m_phase == -1 || m_hemisphere == _T("") ) return;
 
@@ -258,7 +258,7 @@ wxSize TacticsInstrument_Sun::GetSize( int orient, wxSize hint )
       }
 }
 
-void TacticsInstrument_Sun::Draw(wxGCDC* dc)
+void TacticsInstrument_Sun::Draw(myDC* dc)
 {
       wxColour cl;
 

--- a/src/clock.h
+++ b/src/clock.h
@@ -63,7 +63,7 @@ public:
 
     wxSize GetSize( int orient, wxSize hint );
     void SetData( int, double, wxString );
-    void Draw(wxGCDC* dc);
+    void Draw(myDC* dc);
     void SetUtcTime(wxDateTime value);
 
 private:
@@ -81,7 +81,7 @@ public:
     ~TacticsInstrument_Sun(){}
 
     wxSize GetSize( int orient, wxSize hint );
-    void Draw(wxGCDC* dc);
+    void Draw(myDC* dc);
     void SetData( int st, double data, wxString unit );
     void SetUtcTime( wxDateTime value );
 

--- a/src/compass.cpp
+++ b/src/compass.cpp
@@ -66,13 +66,13 @@ void TacticsInstrument_Compass::SetData(int st, double data, wxString unit)
       }
 }
 
-void TacticsInstrument_Compass::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_Compass::DrawBackground(myDC* dc)
 {
     DrawBoat( dc, m_cx, m_cy, m_radius );
     DrawCompassRose( dc, m_cx, m_cy, 0.7 * m_radius, m_AngleStart, true );
 }
 
-void TacticsInstrument_Compass::DrawForeground(wxGCDC* dc)
+void TacticsInstrument_Compass::DrawForeground(myDC* dc)
 {
       // We dont want the default foreground (arrow) drawn
 }

--- a/src/compass.h
+++ b/src/compass.h
@@ -65,8 +65,8 @@ class TacticsInstrument_Compass: public TacticsInstrument_Dial
       private:
 
       protected:
-            void DrawBackground(wxGCDC* dc);
-            void DrawForeground(wxGCDC* dc);
+            void DrawBackground(myDC* dc);
+            void DrawForeground(myDC* dc);
 };
 
 #endif // __Compass_H__

--- a/src/depth.cpp
+++ b/src/depth.cpp
@@ -87,13 +87,13 @@ void TacticsInstrument_Depth::SetData(int st, double data, wxString unit)
       }
 }
 
-void TacticsInstrument_Depth::Draw(wxGCDC* dc)
+void TacticsInstrument_Depth::Draw(myDC* dc)
 {
       DrawBackground(dc);
       DrawForeground(dc);
 }
 
-void TacticsInstrument_Depth::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_Depth::DrawBackground(myDC* dc)
 {
       wxSize size = GetClientSize();
       wxColour cl;
@@ -145,7 +145,7 @@ void TacticsInstrument_Depth::DrawBackground(wxGCDC* dc)
       dc->DrawText(label, size.x-width-1, size.y-height);
 }
 
-void TacticsInstrument_Depth::DrawForeground(wxGCDC* dc)
+void TacticsInstrument_Depth::DrawForeground(myDC* dc)
 {
       wxSize size = GetClientSize();
       wxColour cl;

--- a/src/depth.h
+++ b/src/depth.h
@@ -65,9 +65,9 @@ class TacticsInstrument_Depth: public TacticsInstrument
             wxString m_DepthUnit;
             wxString m_Temp;
 
-            void Draw(wxGCDC* dc);
-            void DrawBackground(wxGCDC* dc);
-            void DrawForeground(wxGCDC* dc);
+            void Draw(myDC* dc);
+            void DrawBackground(myDC* dc);
+            void DrawForeground(myDC* dc);
 };
 
 #endif // __DEPTH_H__

--- a/src/dial.cpp
+++ b/src/dial.cpp
@@ -107,7 +107,7 @@ void TacticsInstrument_Dial::SetData(int st, double data, wxString unit)
   }
 }
 
-void TacticsInstrument_Dial::Draw(wxGCDC* bdc)
+void TacticsInstrument_Dial::Draw(myDC* bdc)
 {
     wxColour c1;
     GetGlobalColor(_T("DASHB"), &c1);
@@ -134,7 +134,7 @@ void TacticsInstrument_Dial::Draw(wxGCDC* bdc)
     DrawForeground(bdc);
 }
 
-void TacticsInstrument_Dial::DrawFrame( wxGCDC* dc )
+void TacticsInstrument_Dial::DrawFrame( myDC* dc )
 {
     wxSize size = GetClientSize();
     wxColour cl;
@@ -196,7 +196,7 @@ void TacticsInstrument_Dial::DrawFrame( wxGCDC* dc )
     }
 }
 
-void TacticsInstrument_Dial::DrawMarkers(wxGCDC* dc)
+void TacticsInstrument_Dial::DrawMarkers(myDC* dc)
 {
     if( m_MarkerOption == DIAL_MARKER_NONE ) return;
 
@@ -245,7 +245,7 @@ void TacticsInstrument_Dial::DrawMarkers(wxGCDC* dc)
     }
 }
 
-void TacticsInstrument_Dial::DrawLabels(wxGCDC* dc)
+void TacticsInstrument_Dial::DrawLabels(myDC* dc)
 {
       if (m_LabelOption == DIAL_LABEL_NONE)
             return;
@@ -340,13 +340,13 @@ void TacticsInstrument_Dial::DrawLabels(wxGCDC* dc)
 
 }
 
-void TacticsInstrument_Dial::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_Dial::DrawBackground(myDC* dc)
 {
       // Nothing to do here right now, will be overwritten
       // by child classes if required
 }
 
-void TacticsInstrument_Dial::DrawData(wxGCDC* dc, double value,
+void TacticsInstrument_Dial::DrawData(myDC* dc, double value,
             wxString unit, wxString format, DialPositionOption position)
 {
       if (position == DIAL_POSITION_NONE)
@@ -462,7 +462,7 @@ void TacticsInstrument_Dial::DrawData(wxGCDC* dc, double value,
       }
 }
 
-void TacticsInstrument_Dial::DrawForeground(wxGCDC* dc)
+void TacticsInstrument_Dial::DrawForeground(myDC* dc)
 {
       // The default foreground is the arrow used in most dials
       wxColour cl;
@@ -516,7 +516,7 @@ void TacticsInstrument_Dial::DrawForeground(wxGCDC* dc)
 }
 
 /* Shared functions */
-void DrawCompassRose(wxGCDC* dc, int cx, int cy, int radius, int startangle, bool showlabels)
+void DrawCompassRose(myDC* dc, int cx, int cy, int radius, int startangle, bool showlabels)
 {
       wxPoint pt, points[3];
       wxString Value;
@@ -583,7 +583,7 @@ void DrawCompassRose(wxGCDC* dc, int cx, int cy, int radius, int startangle, boo
       }
 }
 
-void DrawBoat( wxGCDC* dc, int cx, int cy, int radius )
+void DrawBoat( myDC* dc, int cx, int cy, int radius )
 {
     // Now draw the boat
     wxColour cl;

--- a/src/dial.h
+++ b/src/dial.h
@@ -123,18 +123,18 @@ class TacticsInstrument_Dial: public TacticsInstrument
             DialLabelOption m_LabelOption;
             wxArrayString m_LabelArray;
 
-            virtual void Draw(wxGCDC* dc);
-            virtual void DrawFrame(wxGCDC* dc);
-            virtual void DrawMarkers(wxGCDC* dc);
-            virtual void DrawLabels(wxGCDC* dc);
-            virtual void DrawBackground(wxGCDC* dc);
-            virtual void DrawData(wxGCDC* dc, double value, wxString unit, wxString format, DialPositionOption position);
-            virtual void DrawForeground(wxGCDC* dc);
+            virtual void Draw(myDC* dc);
+            virtual void DrawFrame(myDC* dc);
+            virtual void DrawMarkers(myDC* dc);
+            virtual void DrawLabels(myDC* dc);
+            virtual void DrawBackground(myDC* dc);
+            virtual void DrawData(myDC* dc, double value, wxString unit, wxString format, DialPositionOption position);
+            virtual void DrawForeground(myDC* dc);
 };
 
 /* Shared functions */
-void DrawCompassRose( wxGCDC* dc, int cx, int cy, int radius, int startangle, bool showlabels );
-void DrawBoat( wxGCDC* dc, int cx, int cy, int radius );
+void DrawCompassRose( myDC* dc, int cx, int cy, int radius, int startangle, bool showlabels );
+void DrawBoat( myDC* dc, int cx, int cy, int radius );
 
 #endif // __Dial_H__
 

--- a/src/from_ownship.cpp
+++ b/src/from_ownship.cpp
@@ -47,7 +47,7 @@ TacticsInstrument_FromOwnship::TacticsInstrument_FromOwnship(wxWindow *pparent, 
     s_lon = 99999999;
 }
 
-void TacticsInstrument_FromOwnship::Draw(wxGCDC* dc)
+void TacticsInstrument_FromOwnship::Draw(myDC* dc)
 {
     wxColour cl;
 

--- a/src/from_ownship.h
+++ b/src/from_ownship.h
@@ -65,7 +65,7 @@ protected:
     int               m_cap_flag4;
     int               m_DataHeight;
 
-    void Draw(wxGCDC* dc);
+    void Draw(myDC* dc);
 };
 
 #endif

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -93,14 +93,14 @@ void TacticsInstrument_GPS::SetSatInfo(int cnt, int seq, SAT_INFO sats[4])
       }
 }
 
-void TacticsInstrument_GPS::Draw(wxGCDC* dc)
+void TacticsInstrument_GPS::Draw(myDC* dc)
 {
       DrawFrame(dc);
       DrawBackground(dc);
       DrawForeground(dc);
 }
 
-void TacticsInstrument_GPS::DrawFrame(wxGCDC* dc)
+void TacticsInstrument_GPS::DrawFrame(myDC* dc)
 {
       wxSize size = GetClientSize();
       wxColour cb;
@@ -177,7 +177,7 @@ void TacticsInstrument_GPS::DrawFrame(wxGCDC* dc)
       dc->DrawLine(3, 130, size.x-3, 130);
 }
 
-void TacticsInstrument_GPS::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_GPS::DrawBackground(myDC* dc)
 {
       // Draw SatID
 
@@ -208,7 +208,7 @@ void TacticsInstrument_GPS::DrawBackground(wxGCDC* dc)
 
 }
 
-void TacticsInstrument_GPS::DrawForeground( wxGCDC* dc )
+void TacticsInstrument_GPS::DrawForeground( myDC* dc )
 {
     wxColour cl;
     GetGlobalColor( _T("DASHL"), &cl );

--- a/src/gps.h
+++ b/src/gps.h
@@ -64,10 +64,10 @@ class TacticsInstrument_GPS: public TacticsInstrument
             int m_SatCount;
             SAT_INFO m_SatInfo[12];
 
-            void Draw(wxGCDC* dc);
-            void DrawFrame(wxGCDC* dc);
-            void DrawBackground(wxGCDC* dc);
-            void DrawForeground(wxGCDC* dc);
+            void Draw(myDC* dc);
+            void DrawFrame(myDC* dc);
+            void DrawBackground(myDC* dc);
+            void DrawForeground(myDC* dc);
 };
 
 #endif // __GPS_H__

--- a/src/instrument.cpp
+++ b/src/instrument.cpp
@@ -49,7 +49,8 @@ TacticsInstrument::TacticsInstrument(wxWindow *pparent, wxWindowID id, wxString 
 
       SetBackgroundStyle( wxBG_STYLE_CUSTOM );
       SetDrawSoloInPane(false);
-      wxClientDC dc(this);
+
+      wxClientDC dc( this );
       int width;
       dc.GetTextExtent(m_title, &width, &m_TitleHeight, 0, 0, g_pFontTitle);
 
@@ -113,7 +114,7 @@ void TacticsInstrument::OnPaint( wxPaintEvent& WXUNUSED(event) )
 //    bm.UseAlpha();
 //#endif
 //    wxMemoryDC mdc( bm );
-#if wxUSE_GRAPHICS_CONTEXT
+#if !defined(__WXGTK__) && (wxUSE_GRAPHICS_CONTEXT == 1)
     wxGCDC dc( pdc );
 #else
     wxDC &dc( pdc );
@@ -201,7 +202,7 @@ TacticsInstrument_Single::TacticsInstrument_Single(wxWindow *pparent, wxWindowID
 
 wxSize TacticsInstrument_Single::GetSize( int orient, wxSize hint )
 {
-      wxClientDC dc(this);
+      wxClientDC dc( this );
       int w;
       dc.GetTextExtent(m_title, &w, &m_TitleHeight, 0, 0, g_pFontTitle);
       dc.GetTextExtent(_T("000"), &w, &m_DataHeight, 0, 0, g_pFontData);
@@ -213,7 +214,7 @@ wxSize TacticsInstrument_Single::GetSize( int orient, wxSize hint )
       }
 }
 
-void TacticsInstrument_Single::Draw(wxGCDC* dc)
+void TacticsInstrument_Single::Draw(myDC* dc)
 {
       wxColour cl;
 #ifdef __WXMSW__
@@ -303,7 +304,7 @@ TacticsInstrument_Position::TacticsInstrument_Position(wxWindow *pparent, wxWind
 
 wxSize TacticsInstrument_Position::GetSize( int orient, wxSize hint )
 {
-      wxClientDC dc(this);
+      wxClientDC dc( this );
       int w;
       dc.GetTextExtent(m_title, &w, &m_TitleHeight, 0, 0, g_pFontTitle);
       dc.GetTextExtent(_T("000  00.0000 W"), &w, &m_DataHeight, 0, 0, g_pFontData);
@@ -315,7 +316,7 @@ wxSize TacticsInstrument_Position::GetSize( int orient, wxSize hint )
       }
 }
 
-void TacticsInstrument_Position::Draw(wxGCDC* dc)
+void TacticsInstrument_Position::Draw(myDC* dc)
 {
       wxColour cl;
 

--- a/src/instrument.h
+++ b/src/instrument.h
@@ -34,8 +34,10 @@
   #include "wx/wx.h"
 #endif //precompiled headers
 
-#if !wxUSE_GRAPHICS_CONTEXT
-#define wxGCDC wxDC
+#if !defined(__WXGTK__) && (wxUSE_GRAPHICS_CONTEXT == 1)
+#define myDC wxGCDC
+#else
+#define myDC wxDC
 #endif
 
 // Required GetGlobalColor
@@ -125,7 +127,7 @@ protected:
       int               m_TitleHeight;
       wxString          m_title;
 
-      virtual void Draw(wxGCDC* dc) = 0;
+      virtual void Draw(myDC* dc) = 0;
 private:
     bool m_drawSoloInPane;
 };
@@ -144,7 +146,7 @@ protected:
       wxString          m_format;
       int               m_DataHeight;
 
-      void Draw(wxGCDC* dc);
+      void Draw(myDC* dc);
 };
 
 class TacticsInstrument_Position : public TacticsInstrument
@@ -163,7 +165,7 @@ protected:
       int               m_cap_flag2;
       int               m_DataHeight;
 
-      void Draw(wxGCDC* dc);
+      void Draw(myDC* dc);
 };
 
 #endif

--- a/src/performance.cpp
+++ b/src/performance.cpp
@@ -95,7 +95,7 @@ wxSize TacticsInstrument_PerformanceSingle::GetSize(int orient, wxSize hint)
 /***********************************************************************************
 
 ************************************************************************************/
-void TacticsInstrument_PerformanceSingle::Draw(wxGCDC* dc)
+void TacticsInstrument_PerformanceSingle::Draw(myDC* dc)
 {
 	wxColour cl;
 #ifdef __WXMSW__
@@ -1308,7 +1308,7 @@ void TacticsInstrument_PolarPerformance::SetData(int st, double data, wxString u
     }
   }
 }
-void TacticsInstrument_PolarPerformance::Draw(wxGCDC* dc)
+void TacticsInstrument_PolarPerformance::Draw(myDC* dc)
 {
   m_WindowRect = GetClientRect();
   m_DrawAreaRect = GetClientRect();
@@ -1321,7 +1321,7 @@ void TacticsInstrument_PolarPerformance::Draw(wxGCDC* dc)
 //*********************************************************************************
 // draw boat speed legend (right side)
 //*********************************************************************************
-void  TacticsInstrument_PolarPerformance::DrawBoatSpeedScale(wxGCDC* dc)
+void  TacticsInstrument_PolarPerformance::DrawBoatSpeedScale(myDC* dc)
 {
   wxString label1, label2, label3, label4, label5;
   wxColour cl;
@@ -1386,7 +1386,7 @@ void  TacticsInstrument_PolarPerformance::DrawBoatSpeedScale(wxGCDC* dc)
 //*********************************************************************************
 // draw percent boat speed scale (left side)
 //*********************************************************************************
-void  TacticsInstrument_PolarPerformance::DrawPercentSpeedScale(wxGCDC* dc)
+void  TacticsInstrument_PolarPerformance::DrawPercentSpeedScale(myDC* dc)
 {
   wxString label1, label2, label3, label4, label5;
   wxColour cl;
@@ -1469,7 +1469,7 @@ void  TacticsInstrument_PolarPerformance::DrawPercentSpeedScale(wxGCDC* dc)
 //*********************************************************************************
 //draw background
 //*********************************************************************************
-void TacticsInstrument_PolarPerformance::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_PolarPerformance::DrawBackground(myDC* dc)
 {
   wxString label, label1, label2, label3, label4, label5;
   wxColour cl;
@@ -1503,7 +1503,7 @@ void TacticsInstrument_PolarPerformance::DrawBackground(wxGCDC* dc)
 //*********************************************************************************
 //draw foreground
 //*********************************************************************************
-void TacticsInstrument_PolarPerformance::DrawForeground(wxGCDC* dc)
+void TacticsInstrument_PolarPerformance::DrawForeground(myDC* dc)
 {
   wxColour col;
   double ratioH;

--- a/src/performance.h
+++ b/src/performance.h
@@ -91,7 +91,7 @@ protected:
 	wxString          m_format;
 	int               m_DataHeight;
 	
-	void Draw(wxGCDC* dc);
+	void Draw(myDC* dc);
 private :
 	wxFileConfig     *m_pconfig;
 
@@ -287,13 +287,13 @@ protected:
   int m_currSec, m_lastSec, m_SpdCntperSec, m_DirCntperSec;
   double m_cntSpd, m_cntDir, m_avgSpd, m_avgDir;
 
-  void Draw(wxGCDC* dc);
-  void DrawBackground(wxGCDC* dc);
-  void DrawForeground(wxGCDC* dc);
+  void Draw(myDC* dc);
+  void DrawBackground(myDC* dc);
+  void DrawForeground(myDC* dc);
   void SetMinMaxWindScale();
-  //void DrawWindDirScale(wxGCDC* dc);
-  void DrawBoatSpeedScale(wxGCDC* dc);
-  void DrawPercentSpeedScale(wxGCDC* dc);
+  //void DrawWindDirScale(myDC* dc);
+  void DrawBoatSpeedScale(myDC* dc);
+  void DrawPercentSpeedScale(myDC* dc);
   //wxString GetWindDirStr(wxString WindDir);
 };
 #endif

--- a/src/polarcompass.cpp
+++ b/src/polarcompass.cpp
@@ -186,7 +186,7 @@ void TacticsInstrument_PolarCompass::SetData(int st, double data, wxString unit)
 }
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_PolarCompass::Draw(wxGCDC* bdc)
+void TacticsInstrument_PolarCompass::Draw(myDC* bdc)
 {
 	wxColour c1;
 	GetGlobalColor(_T("DASHB"), &c1);
@@ -241,14 +241,14 @@ void TacticsInstrument_PolarCompass::Draw(wxGCDC* bdc)
 }
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_PolarCompass::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_PolarCompass::DrawBackground(myDC* dc)
 {
 //    DrawCompassRose( dc, m_cx, m_cy, 0.7 * m_radius, m_AngleStart, true );
 	DrawBoat(dc, m_cx, m_cy, m_radius);
 }
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_PolarCompass::DrawBoat(wxGCDC* dc, int cx, int cy, int radius)
+void TacticsInstrument_PolarCompass::DrawBoat(myDC* dc, int cx, int cy, int radius)
 {
   // Now draw the boat
   wxColour cl;
@@ -301,7 +301,7 @@ void TacticsInstrument_PolarCompass::DrawBoat(wxGCDC* dc, int cx, int cy, int ra
  Just a simple line to avoid confusion with BearingCompass' placing the tip onto
  the VMG / CMG markers there.
 ****************************************************************************************/
-void TacticsInstrument_PolarCompass::DrawWindAngles(wxGCDC* dc)
+void TacticsInstrument_PolarCompass::DrawWindAngles(myDC* dc)
 {
 	if (!wxIsNaN(m_TWA)) {
 		wxColour cl;
@@ -378,7 +378,7 @@ void TacticsInstrument_PolarCompass::DrawWindAngles(wxGCDC* dc)
 /***************************************************************************************
 Draw pointers for the optimum target VMG- and CMG Angle (if bearing is available)
 ****************************************************************************************/
-void TacticsInstrument_PolarCompass::DrawTargetxMGAngle(wxGCDC* dc){
+void TacticsInstrument_PolarCompass::DrawTargetxMGAngle(myDC* dc){
   if (!wxIsNaN(m_TWS)) {
     // get Target VMG Angle from Polar
     TargetxMG tvmg_up = BoatPolar->GetTargetVMGUpwind(m_TWS);
@@ -406,7 +406,7 @@ void TacticsInstrument_PolarCompass::DrawTargetxMGAngle(wxGCDC* dc){
 /***************************************************************************************
 Draw pointers for the optimum target VMG- and CMG Angle (if bearing is available)
 ****************************************************************************************/
-void TacticsInstrument_PolarCompass::DrawTargetAngle(wxGCDC* dc, double TargetAngle, wxString color, int size){
+void TacticsInstrument_PolarCompass::DrawTargetAngle(myDC* dc, double TargetAngle, wxString color, int size){
   if (TargetAngle > 0 && !wxIsNaN(m_Hdt) && !wxIsNaN(m_TWD)){
       wxColour cl;
       dc->SetPen(*wxTRANSPARENT_PEN);
@@ -470,7 +470,7 @@ void TacticsInstrument_PolarCompass::DrawTargetAngle(wxGCDC* dc, double TargetAn
 }
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_PolarCompass::DrawForeground(wxGCDC* dc)
+void TacticsInstrument_PolarCompass::DrawForeground(myDC* dc)
 {
   if (!wxIsNaN(m_Bearing))
 		DrawBearing(dc);
@@ -482,7 +482,7 @@ void TacticsInstrument_PolarCompass::DrawForeground(wxGCDC* dc)
 }
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_PolarCompass::DrawBearing(wxGCDC* dc)
+void TacticsInstrument_PolarCompass::DrawBearing(myDC* dc)
 {
 	wxColour cl;
 	// no border for the circle 
@@ -516,7 +516,7 @@ void TacticsInstrument_PolarCompass::DrawBearing(wxGCDC* dc)
 /***************************************************************************************
 ****************************************************************************************/
 #define POLSTEPS 180 //we draw in 2 degree steps
-void TacticsInstrument_PolarCompass::DrawPolar(wxGCDC*dc)
+void TacticsInstrument_PolarCompass::DrawPolar(myDC*dc)
 {
   if (!wxIsNaN(m_TWS) && !wxIsNaN(m_TWD)) {
     wxColour cl;
@@ -554,7 +554,7 @@ void TacticsInstrument_PolarCompass::DrawPolar(wxGCDC*dc)
 
 /***************************************************************************************
 ****************************************************************************************/
-void TacticsInstrument_PolarCompass::DrawData(wxGCDC* dc, double value,
+void TacticsInstrument_PolarCompass::DrawData(myDC* dc, double value,
 	wxString unit, wxString format, DialPositionOption position)
 {
 	if (position == DIAL_POSITION_NONE)
@@ -694,7 +694,7 @@ void TacticsInstrument_PolarCompass::DrawData(wxGCDC* dc, double value,
 /***************************************************************************************
   Calculate & Draw the laylines for the bearing compass 
 ****************************************************************************************/
-void TacticsInstrument_PolarCompass::DrawLaylines(wxGCDC* dc)
+void TacticsInstrument_PolarCompass::DrawLaylines(myDC* dc)
 {
   if (!wxIsNaN(m_Cog) && !wxIsNaN(m_Hdt) && !wxIsNaN(m_lat) && !wxIsNaN(m_lon) && !wxIsNaN(m_TWA) && !wxIsNaN(m_CurrDir) && !wxIsNaN(m_CurrSpeed)){
 

--- a/src/polarcompass.h
+++ b/src/polarcompass.h
@@ -86,17 +86,17 @@ class TacticsInstrument_PolarCompass : public TacticsInstrument_Dial
 		  wxFileConfig     *m_pconfig;
 
       protected:
-            void DrawBackground(wxGCDC* dc);
-			void DrawForeground(wxGCDC* dc);
-			void DrawBearing(wxGCDC* dc);
-			void DrawWindAngles(wxGCDC* dc);
-            void DrawBoat(wxGCDC* dc, int cx, int cy, int radius);
-            void DrawPolar(wxGCDC* dc);
-            void DrawTargetxMGAngle(wxGCDC* dc);
-            void DrawTargetAngle(wxGCDC* dc, double TargetAngle, wxString color1, int size);
-			void DrawLaylines(wxGCDC* dc);
-			virtual void DrawData(wxGCDC* dc, double value, wxString unit, wxString format, DialPositionOption position);
-			virtual void Draw(wxGCDC* dc);
+            void DrawBackground(myDC* dc);
+			void DrawForeground(myDC* dc);
+			void DrawBearing(myDC* dc);
+			void DrawWindAngles(myDC* dc);
+            void DrawBoat(myDC* dc, int cx, int cy, int radius);
+            void DrawPolar(myDC* dc);
+            void DrawTargetxMGAngle(myDC* dc);
+            void DrawTargetAngle(myDC* dc, double TargetAngle, wxString color1, int size);
+			void DrawLaylines(myDC* dc);
+			virtual void DrawData(myDC* dc, double value, wxString unit, wxString format, DialPositionOption position);
+			virtual void Draw(myDC* dc);
 			void CalculateLaylineDegreeRange(void);
 };
 

--- a/src/rudder_angle.cpp
+++ b/src/rudder_angle.cpp
@@ -90,7 +90,7 @@ void TacticsInstrument_RudderAngle::SetData(int st, double data, wxString unit)
       else return;
 }
 
-void TacticsInstrument_RudderAngle::DrawFrame(wxGCDC* dc)
+void TacticsInstrument_RudderAngle::DrawFrame(myDC* dc)
 {
       // We don't need the upper part
       // Move center up
@@ -120,7 +120,7 @@ void TacticsInstrument_RudderAngle::DrawFrame(wxGCDC* dc)
       dc->DrawLine(x1, y1, x2, y2);
 }
 
-void TacticsInstrument_RudderAngle::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_RudderAngle::DrawBackground(myDC* dc)
 {
       wxCoord x = m_cx - (m_radius * 0.3);
       wxCoord y = m_cy - (m_radius * 0.5);

--- a/src/rudder_angle.h
+++ b/src/rudder_angle.h
@@ -55,8 +55,8 @@ class TacticsInstrument_RudderAngle: public TacticsInstrument_Dial
       private:
 
       protected:
-            void DrawFrame(wxGCDC* dc);
-            void DrawBackground(wxGCDC* dc);
+            void DrawFrame(myDC* dc);
+            void DrawBackground(myDC* dc);
 };
 
 #endif // __RudderAngle_H__

--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -53,7 +53,7 @@ TacticsInstrument_Wind::TacticsInstrument_Wind( wxWindow *parent, wxWindowID id,
       SetOptionLabel(30, DIAL_LABEL_HORIZONTAL, wxArrayString(12, labels));
 }
 
-void TacticsInstrument_Wind::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_Wind::DrawBackground(myDC* dc)
 {
     DrawBoat( dc, m_cx, m_cy, m_radius );
 }
@@ -66,7 +66,7 @@ TacticsInstrument_WindCompass::TacticsInstrument_WindCompass( wxWindow *parent, 
       SetOptionLabel(45, DIAL_LABEL_HORIZONTAL, wxArrayString(8, labels));
 }
 
-void TacticsInstrument_WindCompass::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_WindCompass::DrawBackground(myDC* dc)
 {
       DrawCompassRose(dc, m_cx, m_cy, m_radius * 0.85, m_AngleStart, false);
 }
@@ -83,7 +83,7 @@ TacticsInstrument_TrueWindAngle::TacticsInstrument_TrueWindAngle( wxWindow *pare
       SetOptionLabel(30, DIAL_LABEL_HORIZONTAL, wxArrayString(12, labels));
 }
 
-void TacticsInstrument_TrueWindAngle::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_TrueWindAngle::DrawBackground(myDC* dc)
 {
     DrawBoat( dc, m_cx, m_cy, m_radius );
 }
@@ -107,7 +107,7 @@ TacticsInstrument_Dial(parent, id, title, cap_flag, 0, 360, 0, 360)
     m_ExtraValueTrue = NAN;
 }
 
-void TacticsInstrument_AppTrueWindAngle::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_AppTrueWindAngle::DrawBackground(myDC* dc)
 {
 	DrawBoat(dc, m_cx, m_cy, m_radius);
 }
@@ -144,7 +144,7 @@ void TacticsInstrument_AppTrueWindAngle::SetData(int st, double data, wxString u
     if (wxIsNaN(m_ExtraValueTrue)) m_MainValueTrue = NAN;
     Refresh();
 }
-void TacticsInstrument_AppTrueWindAngle::Draw(wxGCDC* bdc)
+void TacticsInstrument_AppTrueWindAngle::Draw(myDC* bdc)
 {
 	wxColour c1;
 	GetGlobalColor(_T("DASHB"), &c1);
@@ -173,7 +173,7 @@ void TacticsInstrument_AppTrueWindAngle::Draw(wxGCDC* bdc)
     DrawData(bdc, m_TWD, m_MainValueTrueUnit, _T("TWD:%.0f"), DIAL_POSITION_INSIDE);
     DrawForeground(bdc);
 }
-void TacticsInstrument_AppTrueWindAngle::DrawForeground(wxGCDC* dc)
+void TacticsInstrument_AppTrueWindAngle::DrawForeground(myDC* dc)
 {
 	wxPoint points[4];
 	double data;
@@ -263,7 +263,7 @@ void TacticsInstrument_AppTrueWindAngle::DrawForeground(wxGCDC* dc)
       dc->DrawPolygon(4, points, 0, 0);
     }
 }
-void TacticsInstrument_AppTrueWindAngle::DrawData(wxGCDC* dc, double value,
+void TacticsInstrument_AppTrueWindAngle::DrawData(myDC* dc, double value,
 	wxString unit, wxString format, DialPositionOption position)
 {
 	if (position == DIAL_POSITION_NONE)

--- a/src/wind.h
+++ b/src/wind.h
@@ -62,7 +62,7 @@ class TacticsInstrument_Wind: public TacticsInstrument_Dial
       private:
 
       protected:
-            void DrawBackground(wxGCDC* dc);
+            void DrawBackground(myDC* dc);
 };
 
 class TacticsInstrument_WindCompass: public TacticsInstrument_Dial
@@ -75,7 +75,7 @@ class TacticsInstrument_WindCompass: public TacticsInstrument_Dial
       private:
 
       protected:
-            void DrawBackground(wxGCDC* dc);
+            void DrawBackground(myDC* dc);
 };
 
 class TacticsInstrument_TrueWindAngle: public TacticsInstrument_Dial
@@ -89,7 +89,7 @@ class TacticsInstrument_TrueWindAngle: public TacticsInstrument_Dial
 
       protected:
 
-            void DrawBackground(wxGCDC* dc);
+            void DrawBackground(myDC* dc);
 };
 /*****************************************************************************
 Apparent & True wind angle combined in one dial instrument
@@ -113,10 +113,10 @@ protected:
     wxString m_TWDUnit;
 	wxString m_ExtraValueAppUnit, m_ExtraValueTrueUnit, m_MainValueAppUnit, m_MainValueTrueUnit;
 	DialPositionOption m_MainValueOption1, m_MainValueOption2, m_ExtraValueOption1, m_ExtraValueOption2;
-	void DrawBackground(wxGCDC* dc);
-	virtual void Draw(wxGCDC* dc);
-	virtual void DrawForeground(wxGCDC* dc);
-	virtual void DrawData(wxGCDC* dc, double value, wxString unit, wxString format, DialPositionOption position);
+	void DrawBackground(myDC* dc);
+	virtual void Draw(myDC* dc);
+	virtual void DrawForeground(myDC* dc);
+	virtual void DrawData(myDC* dc, double value, wxString unit, wxString format, DialPositionOption position);
 
 
 };

--- a/src/wind_history.cpp
+++ b/src/wind_history.cpp
@@ -257,7 +257,7 @@ void TacticsInstrument_WindDirHistory::SetData(int st, double data, wxString uni
   }
 }
 
-void TacticsInstrument_WindDirHistory::Draw(wxGCDC* dc)
+void TacticsInstrument_WindDirHistory::Draw(myDC* dc)
 {
   m_WindowRect = GetClientRect();
   m_DrawAreaRect = GetClientRect();
@@ -313,7 +313,7 @@ void TacticsInstrument_WindDirHistory::SetMinMaxWindScale()
 //*********************************************************************************
 // wind direction legend
 //*********************************************************************************
-void  TacticsInstrument_WindDirHistory::DrawWindDirScale(wxGCDC* dc)
+void  TacticsInstrument_WindDirHistory::DrawWindDirScale(myDC* dc)
 {
   wxString label1, label2, label3, label4, label5;
   wxColour cl;
@@ -381,7 +381,7 @@ void  TacticsInstrument_WindDirHistory::DrawWindDirScale(wxGCDC* dc)
 //*********************************************************************************
 // draw wind speed scale
 //*********************************************************************************
-void  TacticsInstrument_WindDirHistory::DrawWindSpeedScale(wxGCDC* dc)
+void  TacticsInstrument_WindDirHistory::DrawWindSpeedScale(myDC* dc)
 {
   wxString label1, label2, label3, label4, label5;
   wxColour cl;
@@ -461,7 +461,7 @@ void  TacticsInstrument_WindDirHistory::DrawWindSpeedScale(wxGCDC* dc)
 //*********************************************************************************
 //draw background
 //*********************************************************************************
-void TacticsInstrument_WindDirHistory::DrawBackground(wxGCDC* dc)
+void TacticsInstrument_WindDirHistory::DrawBackground(myDC* dc)
 {
   wxString label, label1, label2, label3, label4, label5;
   wxColour cl;
@@ -550,7 +550,7 @@ wxString TacticsInstrument_WindDirHistory::GetWindDirStr(wxString WindDir)
 //*********************************************************************************
 //draw foreground
 //*********************************************************************************
-void TacticsInstrument_WindDirHistory::DrawForeground(wxGCDC* dc)
+void TacticsInstrument_WindDirHistory::DrawForeground(myDC* dc)
 {
   wxColour col;
   double ratioH;

--- a/src/wind_history.h
+++ b/src/wind_history.h
@@ -96,12 +96,12 @@ protected:
   int m_currSec, m_lastSec, m_SpdCntperSec, m_DirCntperSec;
   double m_cntSpd, m_cntDir, m_avgSpd, m_avgDir;
 
-  void Draw(wxGCDC* dc);
-  void DrawBackground(wxGCDC* dc);
-  void DrawForeground(wxGCDC* dc);
+  void Draw(myDC* dc);
+  void DrawBackground(myDC* dc);
+  void DrawForeground(myDC* dc);
   void SetMinMaxWindScale();
-  void DrawWindDirScale(wxGCDC* dc);
-  void DrawWindSpeedScale(wxGCDC* dc);
+  void DrawWindDirScale(myDC* dc);
+  void DrawWindSpeedScale(myDC* dc);
   wxString GetWindDirStr(wxString WindDir);
   void OnWindHistUpdTimer(wxTimerEvent & event);
 };


### PR DESCRIPTION
- Inside OnPaint we get a wxBufferedPaintDC(this) and create a wxGCDC from it.
  The wxGCDC has a constructor from wxMemoryDC, which is used in this case.
  The constructor does not set m_window inside the underlaying wxDCImpl.

- Inside GetSize methods we use a wxClientDC(this) to do dc.GetTextExtent().
  The wxClientDC has a window associated to itself.

- When running on a GTK display with high PPI configured to use a custom
  DPI setting for fonts, the above leads to large sizes returned from GetSize(),
  but only small text drawn from the actual Draw() routines.

Using wxDC instead of wxGCDC preserves the associated window in the
wxBufferedPaintDC, so GetSize() and Draw() use the same font sizes.

I have sent the same pull request to OpenCPN with changes against dashboard_pi.