### PR TITLE
Speed up history database by accessing system time functions only as …

### DIFF
--- a/src/avg_wind.cpp
+++ b/src/avg_wind.cpp
@@ -69,7 +69,7 @@ TacticsInstrument(parent, id, title, OCPN_DBP_STC_TWD)
    mDblsinExpSmoothWindDir = new DoubleExpSmooth(0.06);
    mDblcosExpSmoothWindDir = new DoubleExpSmooth(0.06);
    /* for (int idx = 0; idx < AVG_WIND_RECORDS; idx++) {
-    m_ArrayRecTime[idx] = wxDateTime::Now();
+    m_ArrayRecTime[idx] = wxDateTime::Now().GetTm( );
   }*/
   alpha = 0.1;  //smoothing constant
   wxSize size = GetClientSize();

--- a/src/avg_wind.h
+++ b/src/avg_wind.h
@@ -62,7 +62,7 @@ private:
 
 protected:
   double alpha;
-  wxDateTime m_ArrayRecTime[AVG_WIND_RECORDS];
+  wxDateTime::Tm m_ArrayRecTime[AVG_WIND_RECORDS];
 
   double m_WindDirRange;
   double m_WindDir;

--- a/src/baro_history.cpp
+++ b/src/baro_history.cpp
@@ -67,8 +67,8 @@ TacticsInstrument_BaroHistory::TacticsInstrument_BaroHistory( wxWindow *parent, 
       for (int idx = 0; idx < BARO_RECORD_COUNT; idx++) {
         m_ArrayPressHistory[idx] = -1;
         m_ExpSmoothArrayPressure[idx] = -1;
-        m_ArrayRecTime[idx]=wxDateTime::Now();
-        m_ArrayRecTime[idx].SetYear(999);
+        m_ArrayRecTime[idx] = wxDateTime::Now( ).GetTm( );
+        m_ArrayRecTime[idx].year = 999;
       }
       alpha=0.01;  //smoothing constant
       m_WindowRect=GetClientRect();
@@ -119,7 +119,7 @@ void TacticsInstrument_BaroHistory::SetData(int st, double data, wxString unit)
 
       }
       m_ExpSmoothArrayPressure[BARO_RECORD_COUNT-1]=alpha*m_ArrayPressHistory[BARO_RECORD_COUNT-2]+(1-alpha)*m_ExpSmoothArrayPressure[BARO_RECORD_COUNT-2];
-      m_ArrayRecTime[BARO_RECORD_COUNT-1]=wxDateTime::Now();
+      m_ArrayRecTime[BARO_RECORD_COUNT-1] = wxDateTime::Now( ).GetTm( );
       m_MaxPress   = wxMax(m_Press,m_MaxPress);
 
       m_MinPress   = wxMin(m_MinPress,m_Press);
@@ -272,14 +272,14 @@ void TacticsInstrument_BaroHistory::DrawForeground(wxGCDC* dc)
   dc->SetFont(*g_pFontLabel);
   //determine the time range of the available data (=oldest data value)
   int i=0;
-  while(m_ArrayRecTime[i].GetYear()== 999 && i<BARO_RECORD_COUNT-1) i++;
+  while(m_ArrayRecTime[i].year == 999 && i<BARO_RECORD_COUNT-1) i++;
   if (i == BARO_RECORD_COUNT -1) {  min=0;
     hour=0;
 
   }
   else {
-    min=m_ArrayRecTime[i].GetMinute();
-    hour=m_ArrayRecTime[i].GetHour();
+    min=m_ArrayRecTime[i].min;
+    hour=m_ArrayRecTime[i].hour;
   }
   m_ratioW = double(m_DrawAreaRect.width) / (BARO_RECORD_COUNT-1);
  // dc->DrawText(wxString::Format(_(" Max %.1f Min %.1f since %02d:%02d  Overall Max %.1f Min %.1f "),m_MaxPress,m_MinPress,hour,min,m_TotalMaxPress,m_TotalMinPress), m_LeftLegend+3+2+degw, m_TopLineHeight-degh+5);
@@ -353,10 +353,10 @@ void TacticsInstrument_BaroHistory::DrawForeground(wxGCDC* dc)
   int done=-1;
   wxPoint pointTime;
   for (int idx = 0; idx < BARO_RECORD_COUNT; idx++) {
-    min=m_ArrayRecTime[idx].GetMinute();
-    hour=m_ArrayRecTime[idx].GetHour();
-    if(m_ArrayRecTime[idx].GetYear()!= 999) {
-      if ( (hour*100+min) != done && (min % 5 == 0 ) && (m_ArrayRecTime[idx].GetSecond() == 0 || m_ArrayRecTime[idx].GetSecond() == 1) ) {
+    min=m_ArrayRecTime[idx].min;
+    hour=m_ArrayRecTime[idx].hour;
+    if(m_ArrayRecTime[idx].year != 999) {
+      if ( (hour*100+min) != done && (min % 5 == 0 ) && (m_ArrayRecTime[idx].sec == 0 || m_ArrayRecTime[idx].sec == 1) ) {
         pointTime.x = idx * m_ratioW + 3 + m_LeftLegend;
         dc->DrawLine( pointTime.x, m_TopLineHeight+1, pointTime.x,(m_TopLineHeight+m_DrawAreaRect.height+1) );
         label.Printf(_T("%02d:%02d"), hour,min);

--- a/src/baro_history.cpp
+++ b/src/baro_history.cpp
@@ -254,7 +254,7 @@ void TacticsInstrument_BaroHistory::DrawForeground(wxGCDC* dc)
   wxColour col;
   double ratioH;
   int degw,degh;
-  int width,height,min,hour;
+  int width,height,sec,min,hour;
   wxString WindAngle,WindSpeed;
   wxPen pen;
   wxString label;
@@ -278,8 +278,9 @@ void TacticsInstrument_BaroHistory::DrawForeground(wxGCDC* dc)
 
   }
   else {
-    min=m_ArrayRecTime[i].min;
-    hour=m_ArrayRecTime[i].hour;
+    wxDateTime localTime( m_ArrayRecTime[i] );
+    min=localTime.GetMinute( );
+    hour=localTime.GetHour( );
   }
   m_ratioW = double(m_DrawAreaRect.width) / (BARO_RECORD_COUNT-1);
  // dc->DrawText(wxString::Format(_(" Max %.1f Min %.1f since %02d:%02d  Overall Max %.1f Min %.1f "),m_MaxPress,m_MinPress,hour,min,m_TotalMaxPress,m_TotalMinPress), m_LeftLegend+3+2+degw, m_TopLineHeight-degh+5);
@@ -353,10 +354,12 @@ void TacticsInstrument_BaroHistory::DrawForeground(wxGCDC* dc)
   int done=-1;
   wxPoint pointTime;
   for (int idx = 0; idx < BARO_RECORD_COUNT; idx++) {
-    min=m_ArrayRecTime[idx].min;
-    hour=m_ArrayRecTime[idx].hour;
+    wxDateTime localTime( m_ArrayRecTime[i] );
+    min=localTime.GetMinute( );
+    hour=localTime.GetHour( );
+    sec=localTime.GetSecond( );
     if(m_ArrayRecTime[idx].year != 999) {
-      if ( (hour*100+min) != done && (min % 5 == 0 ) && (m_ArrayRecTime[idx].sec == 0 || m_ArrayRecTime[idx].sec == 1) ) {
+      if ( (hour*100+min) != done && (min % 5 == 0 ) && (sec == 0 || sec == 1) ) {
         pointTime.x = idx * m_ratioW + 3 + m_LeftLegend;
         dc->DrawLine( pointTime.x, m_TopLineHeight+1, pointTime.x,(m_TopLineHeight+m_DrawAreaRect.height+1) );
         label.Printf(_T("%02d:%02d"), hour,min);

--- a/src/baro_history.h
+++ b/src/baro_history.h
@@ -72,7 +72,7 @@ class TacticsInstrument_BaroHistory: public TacticsInstrument
             double m_ArrayPressHistory[BARO_RECORD_COUNT];
             double m_ExpSmoothArrayPressure[BARO_RECORD_COUNT];
 
-   wxDateTime m_ArrayRecTime[BARO_RECORD_COUNT];
+            wxDateTime::Tm m_ArrayRecTime[BARO_RECORD_COUNT];
 
 
 

--- a/src/nmea0183/lat.cpp
+++ b/src/nmea0183/lat.cpp
@@ -80,7 +80,11 @@ void LATITUDE::Set( double position, const wxString& north_or_south )
 
    Latitude = position;
    wxString ts = north_or_south;
-
+   if( north_or_south.IsEmpty() )
+   {
+       Northing = NS_Unknown;
+       return;
+   }
    if ( ts.Trim(false)[ 0 ] == _T('N') )
    {
       Northing = North;

--- a/src/nmea0183/long.cpp
+++ b/src/nmea0183/long.cpp
@@ -80,6 +80,11 @@ void LONGITUDE::Set( double position, const wxString& east_or_west )
 
    Longitude = position;
    wxString ts = east_or_west;
+   if ( east_or_west.IsEmpty() )
+   {
+       Easting = EW_Unknown;
+       return;
+   }
 
    if ( ts.Trim(false)[ 0 ] == 'E' )
    {

--- a/src/performance.cpp
+++ b/src/performance.cpp
@@ -1222,8 +1222,8 @@ TacticsInstrument(parent, id, title, OCPN_DBP_STC_STW | OCPN_DBP_STC_TWA | OCPN_
   for (int idx = 0; idx < DATA_RECORD_COUNT; idx++) {
     m_ArrayPercentSpdHistory[idx] = -1;
     m_ExpSmoothArrayPercentSpd[idx] = -1;
-    m_ArrayRecTime[idx] = wxDateTime::Now();
-    m_ArrayRecTime[idx].SetYear(999);
+    m_ArrayRecTime[idx] = wxDateTime::Now().GetTm( );
+    m_ArrayRecTime[idx].year = 999;
   }
   alpha = 0.01;  //smoothing constant
   m_WindowRect = GetClientRect();
@@ -1297,7 +1297,7 @@ void TacticsInstrument_PolarPerformance::SetData(int st, double data, wxString u
         }
         m_ExpSmoothArrayPercentSpd[DATA_RECORD_COUNT - 1] = alpha*m_ArrayPercentSpdHistory[DATA_RECORD_COUNT - 2] + (1 - alpha)*m_ExpSmoothArrayPercentSpd[DATA_RECORD_COUNT - 2];
         m_ExpSmoothArrayBoatSpd[DATA_RECORD_COUNT - 1] = alpha*m_ArrayBoatSpdHistory[DATA_RECORD_COUNT - 2] + (1 - alpha)*m_ExpSmoothArrayBoatSpd[DATA_RECORD_COUNT - 2];
-        m_ArrayRecTime[DATA_RECORD_COUNT - 1] = wxDateTime::Now();
+        m_ArrayRecTime[DATA_RECORD_COUNT - 1] = wxDateTime::Now().GetTm( );
         //include the new/latest value in the max/min value test too
         m_MaxPercent = wxMax(m_PolarSpeedPercent, m_MaxPercent);
         m_MaxBoatSpd = wxMax(m_STW, m_MaxBoatSpd);
@@ -1583,14 +1583,14 @@ void TacticsInstrument_PolarPerformance::DrawForeground(wxGCDC* dc)
   dc->SetFont(*g_pFontLabel);
   //determine the time range of the available data (=oldest data value)
   int i = 0;
-  while (m_ArrayRecTime[i].GetYear() == 999 && i<DATA_RECORD_COUNT - 1) i++;
+  while (m_ArrayRecTime[i].year == 999 && i<DATA_RECORD_COUNT - 1) i++;
   if (i == DATA_RECORD_COUNT - 1) {
     min = 0;
     hour = 0;
   }
   else {
-    min = m_ArrayRecTime[i].GetMinute();
-    hour = m_ArrayRecTime[i].GetHour();
+    min = m_ArrayRecTime[i].min;
+    hour = m_ArrayRecTime[i].hour;
   }
   // Single text var to facilitate correct translations:
   wxString s_Max = _("Max");
@@ -1651,10 +1651,10 @@ void TacticsInstrument_PolarPerformance::DrawForeground(wxGCDC* dc)
   int done = -1;
   wxPoint pointTime;
   for (int idx = 0; idx < DATA_RECORD_COUNT; idx++) {
-    min = m_ArrayRecTime[idx].GetMinute();
-    hour = m_ArrayRecTime[idx].GetHour();
-    if (m_ArrayRecTime[idx].GetYear() != 999) {
-      if ((hour * 100 + min) != done && (min % 5 == 0) && (m_ArrayRecTime[idx].GetSecond() == 0 || m_ArrayRecTime[idx].GetSecond() == 1)) {
+    min = m_ArrayRecTime[idx].min;
+    hour = m_ArrayRecTime[idx].hour;
+    if (m_ArrayRecTime[idx].year != 999) {
+      if ((hour * 100 + min) != done && (min % 5 == 0) && (m_ArrayRecTime[idx].sec == 0 || m_ArrayRecTime[idx].sec == 1)) {
         pointTime.x = idx * m_ratioW + 3 + m_LeftLegend;
         dc->DrawLine(pointTime.x, m_TopLineHeight + 1, pointTime.x, (m_TopLineHeight + m_DrawAreaRect.height + 1));
         label.Printf(_T("%02d:%02d"), hour, min);

--- a/src/performance.cpp
+++ b/src/performance.cpp
@@ -1508,7 +1508,7 @@ void TacticsInstrument_PolarPerformance::DrawForeground(wxGCDC* dc)
   wxColour col;
   double ratioH;
   int degw, degh;
-  int width, height, min, hour;
+  int width, height, sec, min, hour;
   wxString  BoatSpeed, PercentSpeed;
   wxPen pen;
   wxString label;
@@ -1589,8 +1589,9 @@ void TacticsInstrument_PolarPerformance::DrawForeground(wxGCDC* dc)
     hour = 0;
   }
   else {
-    min = m_ArrayRecTime[i].min;
-    hour = m_ArrayRecTime[i].hour;
+    wxDateTime localTime( m_ArrayRecTime[i] );
+    min = localTime.GetMinute( );
+    hour = localTime.GetHour( );
   }
   // Single text var to facilitate correct translations:
   wxString s_Max = _("Max");
@@ -1651,10 +1652,12 @@ void TacticsInstrument_PolarPerformance::DrawForeground(wxGCDC* dc)
   int done = -1;
   wxPoint pointTime;
   for (int idx = 0; idx < DATA_RECORD_COUNT; idx++) {
-    min = m_ArrayRecTime[idx].min;
-    hour = m_ArrayRecTime[idx].hour;
+	wxDateTime localTime( m_ArrayRecTime[i] );
+    min = localTime.GetMinute( );
+    hour = localTime.GetHour( );
+    sec = localTime.GetSecond( );
     if (m_ArrayRecTime[idx].year != 999) {
-      if ((hour * 100 + min) != done && (min % 5 == 0) && (m_ArrayRecTime[idx].sec == 0 || m_ArrayRecTime[idx].sec == 1)) {
+      if ((hour * 100 + min) != done && (min % 5 == 0) && (sec == 0 || sec == 1)) {
         pointTime.x = idx * m_ratioW + 3 + m_LeftLegend;
         dc->DrawLine(pointTime.x, m_TopLineHeight + 1, pointTime.x, (m_TopLineHeight + m_DrawAreaRect.height + 1));
         label.Printf(_T("%02d:%02d"), hour, min);

--- a/src/performance.h
+++ b/src/performance.h
@@ -264,7 +264,7 @@ protected:
   double m_ArrayBoatSpdHistory[DATA_RECORD_COUNT];
   double m_ExpSmoothArrayBoatSpd[DATA_RECORD_COUNT];
   double m_ExpSmoothArrayPercentSpd[DATA_RECORD_COUNT];
-  wxDateTime m_ArrayRecTime[DATA_RECORD_COUNT];
+  wxDateTime::Tm m_ArrayRecTime[DATA_RECORD_COUNT];
 
   double m_MaxBoatSpd;
   double m_MinBoatSpd;

--- a/src/tactics_pi.cpp
+++ b/src/tactics_pi.cpp
@@ -4086,6 +4086,12 @@ void TacticsWindow::OnContextMenu(wxContextMenuEvent& event)
 {
 	wxMenu* contextMenu = new wxMenu();
 
+    wxAuiPaneInfo& pane = m_pauimgr->GetPane( this );
+    if ( pane.IsOk( ) && pane.IsDocked( ) )
+    {
+        contextMenu->Append( ID_DASH_UNDOCK, _( "Undock" ) );
+    }
+
 	wxMenuItem* btnVertical = contextMenu->AppendRadioItem(ID_DASH_VERTICAL, _("Vertical"));
 	btnVertical->Check(itemBoxSizer->GetOrientation() == wxVERTICAL);
 	wxMenuItem* btnHorizontal = contextMenu->AppendRadioItem(ID_DASH_HORIZONTAL, _("Horizontal"));
@@ -4152,6 +4158,11 @@ void TacticsWindow::OnContextMenuSelect(wxCommandEvent& event)
 		m_plugin->ToggleWindbarbRender(this);
 		return; // Does it's own save.
 	}
+    case ID_DASH_UNDOCK:
+    {
+        ChangePaneOrientation( GetSizerOrientation( ), true );
+        return;     // Nothing changed so nothing need be saved
+    }
 
 	}
 	m_plugin->SaveConfig();

--- a/src/tactics_pi.h
+++ b/src/tactics_pi.h
@@ -391,7 +391,8 @@ enum
 	  ID_DASH_LAYLINE,
       ID_DASH_CURRENT,
       ID_DASH_POLAR,
-      ID_DASH_WINDBARB
+      ID_DASH_WINDBARB,
+      ID_DASH_UNDOCK
 };
 
 class TacticsWindow : public wxWindow

--- a/src/wind_history.cpp
+++ b/src/wind_history.cpp
@@ -73,8 +73,8 @@ TacticsInstrument(parent, id, title, OCPN_DBP_STC_TWD | OCPN_DBP_STC_TWS)
     m_ArrayWindSpdHistory[idx] = -1;
     m_ExpSmoothArrayWindSpd[idx] = -1;
     m_ExpSmoothArrayWindDir[idx] = -1;
-    m_ArrayRecTime[idx] = wxDateTime::Now();
-    m_ArrayRecTime[idx].SetYear(999);
+    m_ArrayRecTime[idx] = wxDateTime::Now( ).GetTm( );
+    m_ArrayRecTime[idx].year = 999;
   }
   alpha = 0.01;  //smoothing constant
   m_WindowRect = GetClientRect();
@@ -126,7 +126,7 @@ void TacticsInstrument_WindDirHistory::OnWindHistUpdTimer(wxTimerEvent & event)
       m_ExpSmoothArrayWindSpd[WIND_RECORD_COUNT - 1] = alpha*m_ArrayWindSpdHistory[WIND_RECORD_COUNT - 2] + (1 - alpha)*m_ExpSmoothArrayWindSpd[WIND_RECORD_COUNT - 2];
       m_ExpSmoothArrayWindDir[WIND_RECORD_COUNT - 1] = alpha*m_ArrayWindDirHistory[WIND_RECORD_COUNT - 2] + (1 - alpha)*m_ExpSmoothArrayWindDir[WIND_RECORD_COUNT - 2];
 
-      m_ArrayRecTime[WIND_RECORD_COUNT - 1] = wxDateTime::Now();
+      m_ArrayRecTime[WIND_RECORD_COUNT - 1] = wxDateTime::Now().GetTm();
       m_oldDirVal = m_ExpSmoothArrayWindDir[WIND_RECORD_COUNT - 1];
       //include the new/latest value in the max/min value test too
       m_MaxWindDir = wxMax(m_WindDir, m_MaxWindDir);
@@ -634,14 +634,14 @@ void TacticsInstrument_WindDirHistory::DrawForeground(wxGCDC* dc)
   dc->SetFont(*g_pFontLabel);
   //determine the time range of the available data (=oldest data value)
   int i = 0;
-  while (m_ArrayRecTime[i].GetYear() == 999 && i<WIND_RECORD_COUNT - 1) i++;
+  while (m_ArrayRecTime[i].year == 999 && i<WIND_RECORD_COUNT - 1) i++;
   if (i == WIND_RECORD_COUNT - 1) {
     min = 0;
     hour = 0;
   }
   else {
-    min = m_ArrayRecTime[i].GetMinute();
-    hour = m_ArrayRecTime[i].GetHour();
+    min = m_ArrayRecTime[i].min;
+    hour = m_ArrayRecTime[i].hour;
   }
   //Single text var to facilitate correc translations:
   wxString s_Max = _("Max");
@@ -700,10 +700,10 @@ void TacticsInstrument_WindDirHistory::DrawForeground(wxGCDC* dc)
   int done = -1;
   wxPoint pointTime;
   for (int idx = 0; idx < WIND_RECORD_COUNT; idx++) {
-    min = m_ArrayRecTime[idx].GetMinute();
-    hour = m_ArrayRecTime[idx].GetHour();
-    if (m_ArrayRecTime[idx].GetYear() != 999) {
-      if ((hour * 100 + min) != done && (min % 5 == 0) && (m_ArrayRecTime[idx].GetSecond() == 0 || m_ArrayRecTime[idx].GetSecond() == 1)) {
+    min = m_ArrayRecTime[idx].min;
+    hour = m_ArrayRecTime[idx].hour;
+    if (m_ArrayRecTime[idx].year != 999) {
+      if ((hour * 100 + min) != done && (min % 5 == 0) && (m_ArrayRecTime[idx].sec == 0 || m_ArrayRecTime[idx].sec == 1)) {
         pointTime.x = idx * m_ratioW + 3 + m_LeftLegend;
         dc->DrawLine(pointTime.x, m_TopLineHeight + 1, pointTime.x, (m_TopLineHeight + m_DrawAreaRect.height + 1));
         label.Printf(_T("%02d:%02d"), hour, min);

--- a/src/wind_history.cpp
+++ b/src/wind_history.cpp
@@ -126,7 +126,7 @@ void TacticsInstrument_WindDirHistory::OnWindHistUpdTimer(wxTimerEvent & event)
       m_ExpSmoothArrayWindSpd[WIND_RECORD_COUNT - 1] = alpha*m_ArrayWindSpdHistory[WIND_RECORD_COUNT - 2] + (1 - alpha)*m_ExpSmoothArrayWindSpd[WIND_RECORD_COUNT - 2];
       m_ExpSmoothArrayWindDir[WIND_RECORD_COUNT - 1] = alpha*m_ArrayWindDirHistory[WIND_RECORD_COUNT - 2] + (1 - alpha)*m_ExpSmoothArrayWindDir[WIND_RECORD_COUNT - 2];
 
-      m_ArrayRecTime[WIND_RECORD_COUNT - 1] = wxDateTime::Now().GetTm();
+      m_ArrayRecTime[WIND_RECORD_COUNT - 1] = wxDateTime::Now().GetTm( );
       m_oldDirVal = m_ExpSmoothArrayWindDir[WIND_RECORD_COUNT - 1];
       //include the new/latest value in the max/min value test too
       m_MaxWindDir = wxMax(m_WindDir, m_MaxWindDir);
@@ -555,7 +555,7 @@ void TacticsInstrument_WindDirHistory::DrawForeground(wxGCDC* dc)
   wxColour col;
   double ratioH;
   int degw, degh;
-  int width, height, min, hour;
+  int width, height, sec, min, hour;
   double dir;
   wxString WindAngle, WindSpeed;
   wxPen pen;
@@ -640,8 +640,9 @@ void TacticsInstrument_WindDirHistory::DrawForeground(wxGCDC* dc)
     hour = 0;
   }
   else {
-    min = m_ArrayRecTime[i].min;
-    hour = m_ArrayRecTime[i].hour;
+    wxDateTime localTime( m_ArrayRecTime[i] );
+    min = localTime.GetMinute( );
+    hour=localTime.GetMinute( );
   }
   //Single text var to facilitate correc translations:
   wxString s_Max = _("Max");
@@ -700,10 +701,12 @@ void TacticsInstrument_WindDirHistory::DrawForeground(wxGCDC* dc)
   int done = -1;
   wxPoint pointTime;
   for (int idx = 0; idx < WIND_RECORD_COUNT; idx++) {
-    min = m_ArrayRecTime[idx].min;
-    hour = m_ArrayRecTime[idx].hour;
-    if (m_ArrayRecTime[idx].year != 999) {
-      if ((hour * 100 + min) != done && (min % 5 == 0) && (m_ArrayRecTime[idx].sec == 0 || m_ArrayRecTime[idx].sec == 1)) {
+    wxDateTime localTime( m_ArrayRecTime[i] );
+    if (localTime.GetYear( ) != 999) {
+      min = localTime.GetMinute( );
+      hour=localTime.GetMinute( );
+      sec=localTime.GetSecond( );
+      if ((hour * 100 + min) != done && (min % 5 == 0) && (sec == 0 || sec == 1)) {
         pointTime.x = idx * m_ratioW + 3 + m_LeftLegend;
         dc->DrawLine(pointTime.x, m_TopLineHeight + 1, pointTime.x, (m_TopLineHeight + m_DrawAreaRect.height + 1));
         label.Printf(_T("%02d:%02d"), hour, min);

--- a/src/wind_history.h
+++ b/src/wind_history.h
@@ -69,7 +69,7 @@ protected:
   double m_ArrayWindSpdHistory[WIND_RECORD_COUNT];
   double m_ExpSmoothArrayWindSpd[WIND_RECORD_COUNT];
   double m_ExpSmoothArrayWindDir[WIND_RECORD_COUNT];
-  wxDateTime m_ArrayRecTime[WIND_RECORD_COUNT];
+  wxDateTime::Tm m_ArrayRecTime[WIND_RECORD_COUNT];
 
   double m_MaxWindDir;
   double m_MinWindDir;


### PR DESCRIPTION
…needed.

Fix crash when lat or long are empty in RMB message

Extracting time elements from wxDateTime is expensive because WX goes
back to the system for time-zone offsets every time an hour or minute
is accessed.  By storing the time vector as wxDateTime::Tm the system
time functions are only accessed once for each new entry in the table.